### PR TITLE
Allow for clock inaccuracies when validating responses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
--   repo: git://github.com/psf/black
-    rev: 21.9b0
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
     hooks:
     - id: black
 -   repo: https://github.com/pycqa/isort
-    rev: 5.9.3
+    rev: 5.10.1
     hooks:
       - id: isort
 -   repo: local

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -34,3 +34,14 @@ In some cases, such as when an :term:`Identity Provider` changes their certifica
 a single certificate object, pass it a collection of certificates. You may check the
 :py:attr:`minisaml.response.Response.certificate` attribute on the :py:class:`minisaml.response.Response` object
 returned by :py:func:`minisaml.response.validate_response` to check which certificate was actually used.
+
+
+Allow for inaccurate clocks
+===========================
+
+:term:`SAML Responses<SAML Response>` include two timestamps limiting the validity period
+of the response, ``NotBefore`` defines the lower bound and ``NotOnOrAfter`` defines the upper bound.
+Since the clocks of different computers are not always in perfect sync, minisaml allows you to define
+a maximum amount of inaccuracy for both of those values when validating responses. To do so,
+provide an instance if :py:class:`minisaml.response.TimeDriftLimits` as the ``allowed_time_drift`` argument
+to :py:func:`minisaml.response.validate_response`.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -26,9 +26,10 @@ API Reference
 
     :param data: :term:`SAML Response` as extracted from the HTTP form field ``SAMLResponse``.
     :param certificate: Certificate or collection of certificates used by the :term:`Identity Provider`.
-    :param expected_audience: :term:`Audience` of your :term:`Identity Provider`.
+    :param expected_audience str: :term:`Audience` of your :term:`Identity Provider`.
     :param signature_verification_config: If the :term:`Identity Provider` uses an algorithm other than SHA-256 for
         response signing, you have to enable it by passing an appropriate :py:class:`minisignxml.config.VerifyConfig` instance.
+    :param allowed_time_drift: Limits the amount of clock inaccuracy tolerated. Defaults to no inaccuracy allowed.
     :returns: Validated response.
     :raises minisaml.errors.MalformedSAMLResponse:
     :raises minisaml.errors.ResponseExpired:
@@ -116,3 +117,20 @@ API Reference
         :type: Dict[str, str]
 
         Extra XML attributes on the attribute element.
+
+
+``minisaml.response.TimeDriftLimits``
+=====================================
+
+.. py:class:: minisaml.response.TimeDriftLimits
+
+    .. py:attribute:: not_before_max_drift
+        :type: datetime.timedelta
+
+    .. py:attribute:: not_on_or_after_max_drift
+        :type: datetime.timedelta
+
+    .. py:method:: none()
+        :classmethod:
+
+        Returns an instance which allows for no drift.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ python = "^3.7"
 minisignxml = ">=22.4"
 lxml = ">=4.4.1"
 yarl = ">=1.4.2"
-sphinx = { version = "^3.2.0", optional = true }
-sphinxcontrib-mermaid = { version = "^0.4.0", optional = true }
 
 [tool.poetry.extras]
 docs = ["sphinx", "sphinxcontrib-mermaid"]
@@ -34,18 +32,17 @@ docs = ["sphinx", "sphinxcontrib-mermaid"]
 [tool.poetry.dev-dependencies]
 pytest = ">=5.2"
 pytest-freezegun = "^0.4.2"
-isort = ">=5.8.0"
-black = ">=21.9b0"
+isort = "5.10.1"
+black = "22.3"
 cryptography = ">=2.8"
 cffi = ">=1.14.0"
 flask = ">=1.1.2"
 mypy = ">=0.782"
+Sphinx = "^4.2"
+sphinxcontrib-mermaid = "^0.7.0"
 
 [tool.isort]
-line_length = "88"
-multi_line_output = "3"
-combine_as_imports = "1"
-include_trailing_comma = "True"
+profile = "black"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/src/minisaml/errors.py
+++ b/src/minisaml/errors.py
@@ -1,3 +1,7 @@
+import datetime
+from dataclasses import dataclass
+
+
 class MiniSAMLError(Exception):
     pass
 
@@ -6,16 +10,19 @@ class MalformedSAMLResponse(MiniSAMLError):
     pass
 
 
+@dataclass
 class ResponseExpired(MiniSAMLError):
-    pass
+    observed_time: datetime.datetime
+    not_on_or_after: datetime.datetime
 
 
+@dataclass
 class ResponseTooEarly(MiniSAMLError):
-    pass
+    observed_time: datetime.datetime
+    not_before: datetime.datetime
 
 
+@dataclass
 class AudienceMismatch(MiniSAMLError):
-    def __init__(self, *, received_audience: str, expected_audience: str):
-        self.received_audience = received_audience
-        self.expected_audience = expected_audience
-        super().__init__()
+    received_audience: str
+    expected_audience: str


### PR DESCRIPTION
Fixes #19 

default behavior stays the same, since I can't think of a good default value even though for `NotBefore` allow some drift is probably reasonable in most cases.