### PR TITLE
Improve docs, change theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ release = "20.8b0"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinxcontrib.mermaid", "sphinx.ext.autodoc"]
+extensions = ["sphinxcontrib.mermaid", "sphinx.ext.autodoc", "sphinx.ext.intersphinx"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -46,9 +46,15 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "alabaster"
+html_theme = "furo"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "cryptography": ("https://cryptography.io/en/latest/", None),
+}

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -36,6 +36,8 @@ a single certificate object, pass it a collection of certificates. You may check
 returned by :py:func:`minisaml.response.validate_response` to check which certificate was actually used.
 
 
+.. _inaccurate-clocks:
+
 Allow for inaccurate clocks
 ===========================
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -26,7 +26,7 @@ API Reference
 
     :param data: :term:`SAML Response` as extracted from the HTTP form field ``SAMLResponse``.
     :param certificate: Certificate or collection of certificates used by the :term:`Identity Provider`.
-    :param expected_audience str: :term:`Audience` of your :term:`Identity Provider`.
+    :param expected_audience: :term:`Audience` of your :term:`Identity Provider`.
     :param signature_verification_config: If the :term:`Identity Provider` uses an algorithm other than SHA-256 for
         response signing, you have to enable it by passing an appropriate :py:class:`minisignxml.config.VerifyConfig` instance.
     :param allowed_time_drift: Limits the amount of clock inaccuracy tolerated. Defaults to no inaccuracy allowed.
@@ -134,3 +134,64 @@ API Reference
         :classmethod:
 
         Returns an instance which allows for no drift.
+
+
+Errors
+======
+
+
+.. py:class:: minisaml.errors.MiniSAMLError
+
+    Base error for all errors raised by MiniSAML itself.
+
+.. py:class:: minisaml.errors.MalformedSAMLResponse
+
+    Raised if the :term:`SAML Response` XML is malformed. This is most likely due to a bug in the :term:`Identity Provider`.
+
+.. py:class:: minisaml.errors.ResponseExpired
+
+    Raised if the :term:`SAML Response` is expired. See :ref:`inaccurate-clocks` if you think this
+    exception is raised incorrectly.
+
+    .. py:attribute:: observed_time
+        :type: datetime.datetime
+
+        The datetime observed on our machine.
+
+    .. py:attribute:: no_on_or_after
+        :type: datetime.datetime
+
+        The datetime required by the :term:`SAML Response`
+
+
+.. py:class:: minisaml.errors.ResponseTooEarly
+
+    Raised if the :term:`SAML Response` was created in the future. See :ref:`inaccurate-clocks` if you think this
+    exception is raised incorrectly.
+
+    .. py:attribute:: observed_time
+        :type: datetime.datetime
+
+        The datetime observed on our machine.
+
+    .. py:attribute:: not_before
+        :type: datetime.datetime
+
+        The datetime required by the :term:`SAML Response`
+
+.. py:class:: minisaml.errors.AudienceMismatch
+
+    Raised if the audience in the :term:`SAML Response` does not match what was expected.
+    This is either due to a misconfiguration in the :term:`Identity Provider` or due to the wrong
+    value being passed as ``expected_audience`` to :py:func:`minisaml.response.validate_response`.
+
+    .. py:attribute:: received_audience
+        :type: str
+
+        The audience value in the :term:`SAML Response`
+
+    .. py:attribute:: expected_audience
+        :type: str
+
+        The audience we expected.
+

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -68,7 +68,7 @@ When your handler is called, read the :term:`SAML Response` from the HTTP Reques
 form encoded data and the :term:`SAML Response` is in a field named ``SAMLResponse``. Pass the value of that field,
 unaltered, to MiniSAML to parse and verify the response.
 
-Once you have your ``SAMLResponse``, call :py:func:`validate_response`.
+Once you have your ``SAMLResponse``, call :py:func:`minisaml.response.validate_response`.
 
 For a detailed description of the arguments that function takes, please refer to its API reference. The
 most basic call requires three keyword arguments:
@@ -93,7 +93,7 @@ encoded file and you have the :term:`SAML Response` data in a variable called ``
         expected_audience='https://sp.invalid/example/'
     )
 
-:py:func:`validate_response` will either return a :py:class:`minisaml.response.Response` if the :term:`SAML Response`
+:py:func:`minisaml.response.validate_response` will either return a :py:class:`minisaml.response.Response` if the :term:`SAML Response`
 was valid, or otherwise raise an exception. See the API reference for what exceptions may be raised.
 
 For detailed descriptions of the data available on a :py:class:`minisaml.response.Response` instance, refer to the API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ flask = ">=1.1.2"
 mypy = ">=0.782"
 Sphinx = "^4.2"
 sphinxcontrib-mermaid = "^0.7.0"
+furo = "^2022.4.7"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Changes the sphinx theme used for docs since the one used before breaks
a bit on the api reference page.
Add more documentation and use intersphinx to link to external
documentation.

Sadly, there's still a problem with autodoc for `validate_response` where types are not linked correctly, but that was also the case in the previous setup. 

<img width="819" alt="Screen Shot 2022-05-13 at 18 26 47" src="https://user-images.githubusercontent.com/141122/168254298-04e7e5d6-d857-40f5-b6ad-71c91c510ff9.png">

