### PR TITLE
do not overwrite original query of the endpoint

### DIFF
--- a/src/minisaml/request.py
+++ b/src/minisaml/request.py
@@ -31,4 +31,4 @@ def get_request_redirect_url(
     }
     if relay_state is not None:
         query["RelayState"] = relay_state
-    return str(URL(saml_endpoint).with_query(query))
+    return str(URL(saml_endpoint).update_query(query))

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -29,3 +29,28 @@ def test_base64_encoding(time_machine: TimeMachineFixture) -> None:
         url
         == "https://saml.invalid/?SAMLRequest=fZHPSsNAEMZfJew9f%2BnFoSlUixioGtroobd1M7ULyWzc2S16tSC%2Bks/TFzGmKgWxx5n55jffx4xZtk0HU%2B82tMAnj%2ByC57YhhmGQC28JjGTNQLJFBqdgOb2eQxYl0FnjjDKNCKbMaJ02dGGIfYt2iXarFd4t5rnYONcxxLFUHGnaykbXIihmudjv3vavH/vde18yeyyInSSXiyzJkjA5C9NRlY4gSyBNVyIov8%2Bda6o1PZ729nAQMVxVVRmWt8tKBPdouffY86NETMZfCWE4bI8yn8bKn6BiIn2tkRSO4yPQgdrBTb9ZzErTaPUSXBrbSvc/OI3SoaPrcD1IwRN3qPRaY90bjf8yf5vHn5t8Ag%3D%3D"
     )
+
+
+def test_endpoint_url_merge(time_machine: TimeMachineFixture) -> None:
+    time_machine.move_to(
+        datetime.datetime(
+            year=2020,
+            month=9,
+            day=14,
+            hour=14,
+            minute=20,
+            second=11,
+            tzinfo=datetime.timezone.utc,
+        )
+    )
+    url = get_request_redirect_url(
+        saml_endpoint="https://saml.invalid/?idpid=abcdef",
+        expected_audience="audience",
+        acs_url="https://acs.invalid",
+        request_id="テスト",
+        force_reauthentication=False,
+    )
+    assert (
+        url
+        == "https://saml.invalid/?idpid=abcdef&SAMLRequest=fZHPSsNAEMZfJew9f%2BnFoSlUixioGtroobd1M7ULyWzc2S16tSC%2Bks/TFzGmKgWxx5n55jffx4xZtk0HU%2B82tMAnj%2ByC57YhhmGQC28JjGTNQLJFBqdgOb2eQxYl0FnjjDKNCKbMaJ02dGGIfYt2iXarFd4t5rnYONcxxLFUHGnaykbXIihmudjv3vavH/vde18yeyyInSSXiyzJkjA5C9NRlY4gSyBNVyIov8%2Bda6o1PZ729nAQMVxVVRmWt8tKBPdouffY86NETMZfCWE4bI8yn8bKn6BiIn2tkRSO4yPQgdrBTb9ZzErTaPUSXBrbSvc/OI3SoaPrcD1IwRN3qPRaY90bjf8yf5vHn5t8Ag%3D%3D"
+    )

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -4,7 +4,7 @@ import pytest
 from time_machine import TimeMachineFixture
 
 from minisaml.request import get_request_redirect_url
-
+from yarl import URL
 
 def test_base64_encoding(time_machine: TimeMachineFixture) -> None:
     time_machine.move_to(
@@ -31,18 +31,7 @@ def test_base64_encoding(time_machine: TimeMachineFixture) -> None:
     )
 
 
-def test_endpoint_url_merge(time_machine: TimeMachineFixture) -> None:
-    time_machine.move_to(
-        datetime.datetime(
-            year=2020,
-            month=9,
-            day=14,
-            hour=14,
-            minute=20,
-            second=11,
-            tzinfo=datetime.timezone.utc,
-        )
-    )
+def test_endpoint_url_merge() -> None:
     url = get_request_redirect_url(
         saml_endpoint="https://saml.invalid/?idpid=abcdef",
         expected_audience="audience",
@@ -50,7 +39,8 @@ def test_endpoint_url_merge(time_machine: TimeMachineFixture) -> None:
         request_id="テスト",
         force_reauthentication=False,
     )
-    assert (
-        url
-        == "https://saml.invalid/?idpid=abcdef&SAMLRequest=fZHPSsNAEMZfJew9f%2BnFoSlUixioGtroobd1M7ULyWzc2S16tSC%2Bks/TFzGmKgWxx5n55jffx4xZtk0HU%2B82tMAnj%2ByC57YhhmGQC28JjGTNQLJFBqdgOb2eQxYl0FnjjDKNCKbMaJ02dGGIfYt2iXarFd4t5rnYONcxxLFUHGnaykbXIihmudjv3vavH/vde18yeyyInSSXiyzJkjA5C9NRlY4gSyBNVyIov8%2Bda6o1PZ729nAQMVxVVRmWt8tKBPdouffY86NETMZfCWE4bI8yn8bKn6BiIn2tkRSO4yPQgdrBTb9ZzErTaPUSXBrbSvc/OI3SoaPrcD1IwRN3qPRaY90bjf8yf5vHn5t8Ag%3D%3D"
-    )
+
+    query = URL(url).query.keys()
+    
+    assert 'idpid' in query
+    assert 'SAMLRequest' in query

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -2,9 +2,9 @@ import datetime
 
 import pytest
 from time_machine import TimeMachineFixture
+from yarl import URL
 
 from minisaml.request import get_request_redirect_url
-from yarl import URL
 
 
 def test_base64_encoding(time_machine: TimeMachineFixture) -> None:

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -6,6 +6,7 @@ from time_machine import TimeMachineFixture
 from minisaml.request import get_request_redirect_url
 from yarl import URL
 
+
 def test_base64_encoding(time_machine: TimeMachineFixture) -> None:
     time_machine.move_to(
         datetime.datetime(
@@ -41,6 +42,6 @@ def test_endpoint_url_merge() -> None:
     )
 
     query = URL(url).query.keys()
-    
-    assert 'idpid' in query
-    assert 'SAMLRequest' in query
+
+    assert "idpid" in query
+    assert "SAMLRequest" in query


### PR DESCRIPTION
google's `saml_endpoint` looks like this: `https://accounts.google.com/o/saml2?idpid=xxxxxxx`, and this `idpid` param is later expected to still be present. `with_query` is replacing query with the built one, `update_query` is merging original query one with the `SAMLRequest` param.