### PR TITLE
Fix Sphinx Documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,10 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import cryptography.x509
+
+# Without this remapping, autodoc is unable to interlink cryptography docs
+cryptography.x509.Certificate.__module__ = "cryptography.x509"
 
 # -- Project information -----------------------------------------------------
 from pathlib import Path
@@ -69,3 +73,5 @@ html_theme = "furo"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
+
+autodoc_preserve_defaults = True

--- a/src/minisaml/response.py
+++ b/src/minisaml/response.py
@@ -71,6 +71,10 @@ class TimeDriftLimits:
 
 @dataclass(frozen=True)
 class ValidationConfig:
+    """
+    ValidationConfig(certificate, signature_verification_config=VerifyConfig.default(), allowed_time_drift=TimeDriftLimits.none())
+    """
+
     certificate: Certificate | Collection[Certificate]
     signature_verification_config: VerifyConfig = VerifyConfig.default()
     allowed_time_drift: TimeDriftLimits = TimeDriftLimits.none()


### PR DESCRIPTION
Resolves #24

The cryptography `Certificates` reference in the documentation currently displays the rust bindings. This means that Sphinx is unable to use `intersphinx_mapping` to link them. By importing it and overwriting `__module__`, docs generation works as expected. 
<img width="872" height="694" alt="image" src="https://github.com/user-attachments/assets/da72fa85-f758-44e8-bd7f-4c310fba7d6d" />

Seems like the default values for `ValidationConfig` are causing problems and making the docs "restate" the attributes here. Including a docstring lets us overwrite the displayed text with something cleaner, reserving the more descriptive but more complex types for the attributes below.
<img width="802" height="446" alt="image" src="https://github.com/user-attachments/assets/e1cc0cbf-b405-4a54-bce3-06a4fa2272a0" />
